### PR TITLE
Set splash as start screen

### DIFF
--- a/app/src/main/java/com/simuel/onebitllm/MainActivity.kt
+++ b/app/src/main/java/com/simuel/onebitllm/MainActivity.kt
@@ -4,13 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.simuel.onebitllm.ui.navigation.BitnetNavGraph
 import com.simuel.onebitllm.ui.theme.OnebitLLMTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +13,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             OnebitLLMTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                BitnetNavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    OnebitLLMTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/simuel/onebitllm/ui/navigation/BitnetNavGraph.kt
+++ b/app/src/main/java/com/simuel/onebitllm/ui/navigation/BitnetNavGraph.kt
@@ -1,0 +1,47 @@
+package com.simuel.onebitllm.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.simuel.onebitllm.ui.chatlist.ChatListScreen
+import com.simuel.onebitllm.ui.splash.SplashRoute
+
+/**
+ * App navigation graph. Starts at [Splash] and navigates to [ChatList].
+ */
+object BitnetDestination {
+    const val Splash = "splash"
+    const val ChatList = "chat_list"
+}
+
+@Composable
+fun BitnetNavGraph(
+    navController: NavHostController = rememberNavController()
+) {
+    NavHost(
+        navController = navController,
+        startDestination = BitnetDestination.Splash
+    ) {
+        addSplash(navController)
+        addChatList()
+    }
+}
+
+private fun NavGraphBuilder.addSplash(navController: NavHostController) {
+    composable(BitnetDestination.Splash) {
+        SplashRoute(onNavigateToChatList = {
+            navController.navigate(BitnetDestination.ChatList) {
+                popUpTo(BitnetDestination.Splash) { inclusive = true }
+            }
+        })
+    }
+}
+
+private fun NavGraphBuilder.addChatList() {
+    composable(BitnetDestination.ChatList) {
+        ChatListScreen()
+    }
+}


### PR DESCRIPTION
## Summary
- add navigation graph starting at `Splash` and moving to `ChatList`
- hook navigation graph in `MainActivity`

## Testing
- `./gradlew test --quiet` *(fails: No route to host)*